### PR TITLE
Fix query sanitizing (newlines and phrases).

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ Changes
   * Upgrade to this version is required, since Bing [retired v2 of their API](
   https://msdn.microsoft.com/en-us/library/mt707570.aspx) which was used by
   v1.0.1 of this library.
+* 5.0.2
+  * Normalize whitespace in query strings and don't quote already quoted
+  pharses.
 
 Upgrading
 ---------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bing.search",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "NodeJS Bing Search client",
   "main": "lib/search.js",
   "repository": {

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -55,7 +55,7 @@ class Search
 
   # Normalize whitespace and then quote phrases.
   sanitizeQuery: (query) ->
-    query = query.replace /\s{2,}|\v/g, ' '
+    query = query.replace /\s{2,}|[\v\r\n]+/g, ' '
     unless '"' in query then '"' + query + '"' else query
 
   executeSearch: (options..., callback) ->

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -53,9 +53,9 @@ class Search
     options.q = @quote options.q
     options
 
+  # Quotes the phrase, unless deeper phrases already exist.
   quote: (str) ->
-    str = str.replace '"', '\"' # Escape existing quotes.
-    str.replace /^|$/g, '"'     # Quote entire phrase.
+    unless '"' in str then '"' + str + '"' else str
 
   executeSearch: (options..., callback) ->
     options = options[0] or {}

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -50,12 +50,13 @@ class Search
       options.mkt = options.market if option.market in markets
       delete options.market
 
-    options.q = @quote options.q
+    options.q = @sanitizeQuery options.q
     options
 
-  # Quotes the phrase, unless deeper phrases already exist.
-  quote: (str) ->
-    unless '"' in str then '"' + str + '"' else str
+  # Normalize whitespace and then quote phrases.
+  sanitizeQuery: (query) ->
+    query = query.replace /\s{2,}|\v/g, ' '
+    unless '"' in query then '"' + query + '"' else query
 
   executeSearch: (options..., callback) ->
     options = options[0] or {}

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -55,7 +55,7 @@ class Search
 
   # Normalize whitespace and then quote phrases.
   sanitizeQuery: (query) ->
-    query = query.replace /\s{2,}|[\v\r\n]+/g, ' '
+    query = query.replace /\s{2,}|[\r\n]+/g, ' '
     unless '"' in query then '"' + query + '"' else query
 
   executeSearch: (options..., callback) ->

--- a/test/search.coffee
+++ b/test/search.coffee
@@ -33,12 +33,7 @@ describe 'search', ->
       search.sanitizeQuery('"Moz"').should.eql '"Moz"'
       done()
     it 'should normalize crazy whitespace', (done) ->
-      input = """
-A
-
-B     C
-"""
-      search.sanitizeQuery(input).should.eql '"A B C"'
+      search.sanitizeQuery(decodeURIComponent 'A%0AB%20%20%20C').should.eql '"A B C"'
       done()
 
   describe 'counts', ->

--- a/test/search.coffee
+++ b/test/search.coffee
@@ -25,12 +25,20 @@ describe 'search', ->
       out = JSON.stringify nock.recorder.play(), null, 2
       fs.writeFileSync RECORDED_FILE, out
 
-  describe 'quote', ->
+  describe 'sanitizeQuery', ->
     it 'should put a phrase in quotes', (done) ->
-      search.quote('Moz').should.eql '"Moz"'
+      search.sanitizeQuery('Moz').should.eql '"Moz"'
       done()
     it 'should not change pre-quoted phrases', (done) ->
-      search.quote('"Moz"').should.eql '"Moz"'
+      search.sanitizeQuery('"Moz"').should.eql '"Moz"'
+      done()
+    it 'should normalize crazy whitespace', (done) ->
+      input = """
+A
+
+B     C
+"""
+      search.sanitizeQuery(input).should.eql '"A B C"'
       done()
 
   describe 'counts', ->

--- a/test/search.coffee
+++ b/test/search.coffee
@@ -29,8 +29,8 @@ describe 'search', ->
     it 'should put a phrase in quotes', (done) ->
       search.quote('Moz').should.eql '"Moz"'
       done()
-    it 'should escape quotes within phrases', (done) ->
-      search.quote('"Moz"').should.eql '"\"Moz\""'
+    it 'should not change pre-quoted phrases', (done) ->
+      search.quote('"Moz"').should.eql '"Moz"'
       done()
 
   describe 'counts', ->


### PR DESCRIPTION
Some of our queries used newline characters, which would cause Bing to fail. Also, I noticed that most of our queries are in a more advanced format, so we no longer surround everything in quotes if quotes already exist in the string.